### PR TITLE
chore: consolidate esno and esmo

### DIFF
--- a/esmo.mjs
+++ b/esmo.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import 'tsx/dist/cli.js'

--- a/package.json
+++ b/package.json
@@ -6,18 +6,17 @@
   "repository": "https://github.com/antfu/esno.git",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "scripts": {
-    "release": "npx bumpp --tag --commit --push && node esmo.mjs publish.ts"
+    "release": "npx bumpp --tag --commit --push && npx tsx publish.ts"
   },
   "dependencies": {
     "tsx": "^3.1.0"
   },
   "bin": {
     "esno": "esno.js",
-    "esmo": "esmo.mjs"
+    "esmo": "esno.js"
   },
   "files": [
-    "esno.js",
-    "esmo.mjs"
+    "esno.js"
   ],
   "devDependencies": {
     "fsxx": "^0.0.5",


### PR DESCRIPTION
We should be able to consolidate the two files: either to `.mjs` with import statement or `.js` with dynamic import.